### PR TITLE
Tranfer the stress strain attr when reforging a tool head

### DIFF
--- a/Toolsmith/ToolTinkering/Blocks/BlockEntityWorkbench.cs
+++ b/Toolsmith/ToolTinkering/Blocks/BlockEntityWorkbench.cs
@@ -1,4 +1,5 @@
-﻿using SmithingPlus.Util;
+﻿using ScientificSmithy.Utils;
+using SmithingPlus.Util;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -337,6 +338,11 @@ namespace Toolsmith.ToolTinkering.Blocks {
 
             if (world.Api.ModLoader.IsModEnabled("canjewelry")) {
                 TinkeringUtility.HandleGemDropsForJewelry(byPlayer.Entity, reforgingSlot.Itemstack);
+            }
+
+            if (world.Api.ModLoader.IsModEnabled("scientificsmithy"))
+            {
+                TinkeringUtility.HandleStressStrainTransfer(workItem, reforgingSlot.Itemstack, world.Api);
             }
 
             //Generate the complete work item voxel data from the recipe.

--- a/Toolsmith/ToolTinkering/TinkeringUtility.cs
+++ b/Toolsmith/ToolTinkering/TinkeringUtility.cs
@@ -20,6 +20,7 @@ using Vintagestory.API.Config;
 using Toolsmith.ToolTinkering.Drawbacks;
 using Vintagestory.API.Datastructures;
 using canjewelry.src;
+using ScientificSmithy.Utils;
 
 namespace Toolsmith.ToolTinkering {
     //This is beginning to hold the MEAT of the whole tinkering system. It has various helper functions that are being used in multiple places to help keep everything just running the single code calls and ensuring it isn't spaghetti while I add more ways to do the same things.
@@ -1079,6 +1080,11 @@ namespace Toolsmith.ToolTinkering {
             } else {
                 return false;
             }
+        }
+
+        public static void HandleStressStrainTransfer(ItemStack outStack, ItemStack inStack, ICoreAPI api)
+        {
+            outStack.TransferStressStrainAttr(inStack, api);
         }
     }
 }


### PR DESCRIPTION
Makes it so reforging a tool head transfers the stress strain attr to the work item instead of creating a new one with the attr at 0