### PR TITLE
Workbench null-shape NRE + tool-head/ground-storage dupe fix

### DIFF
--- a/Toolsmith/ToolTinkering/Behaviors/CollectibleBehaviorToolHead.cs
+++ b/Toolsmith/ToolTinkering/Behaviors/CollectibleBehaviorToolHead.cs
@@ -11,6 +11,7 @@ using Vintagestory.API.Common;
 using Vintagestory.API.Common.Entities;
 using Vintagestory.API.Config;
 using Vintagestory.API.Datastructures;
+using Vintagestory.GameContent;
 using Vintagestory.Server;
 
 namespace Toolsmith.ToolTinkering.Behaviors {
@@ -33,6 +34,14 @@ namespace Toolsmith.ToolTinkering.Behaviors {
         
         public override void OnHeldInteractStart(ItemSlot slot, EntityAgent byEntity, BlockSelection blockSel, EntitySelection entitySel, bool firstEvent, ref EnumHandHandling handHandling, ref EnumHandling handling) { //Handle the grinding code here as well as the tool itself! Probably can offload the core interaction to a helper utility function?
             var entPlayer = (byEntity as EntityPlayer);
+
+            //If clicking on a ground-storage block, defer to vanilla deposit. Prevents the crafting
+            //intercept from racing with BlockEntityGroundStorage's accept path, which was duping
+            //heads when the player clicked a partially occupied quadrant with a valid handle in offhand.
+            if (blockSel != null && byEntity.World.BlockAccessor.GetBlockEntity(blockSel.Position) is BlockEntityGroundStorage) {
+                base.OnHeldInteractStart(slot, byEntity, blockSel, entitySel, firstEvent, ref handHandling, ref handling);
+                return;
+            }
 
             if (TinkeringUtility.ValidHandleInOffhand(byEntity)) { //Check for Handle in Offhand
                 handHandling = EnumHandHandling.PreventDefault;

--- a/Toolsmith/ToolTinkering/Blocks/BlockEntityWorkbench.cs
+++ b/Toolsmith/ToolTinkering/Blocks/BlockEntityWorkbench.cs
@@ -617,15 +617,20 @@ namespace Toolsmith.ToolTinkering.Blocks {
             }
 
             if (mesh == null) {
-                Shape shape;
+                Shape shape = null;
                 if (stack.Class == EnumItemClass.Item) {
                     if ((stack.Item as ItemWorkItem) != null) {
                         return new MeshData();
-                    } else {
-                        shape = capi.TesselatorManager.GetCachedShape(stack.Item.Shape.Base);
+                    }
+                    AssetLocation shapeBase = stack.Item?.Shape?.Base;
+                    if (shapeBase != null) {
+                        shape = capi.TesselatorManager.GetCachedShape(shapeBase);
                     }
                 } else {
-                    shape = capi.TesselatorManager.GetCachedShape(stack.Block.Shape.Base);
+                    AssetLocation shapeBase = stack.Block?.Shape?.Base;
+                    if (shapeBase != null) {
+                        shape = capi.TesselatorManager.GetCachedShape(shapeBase);
+                    }
                 }
 
                 if (shape == null) {
@@ -728,15 +733,20 @@ namespace Toolsmith.ToolTinkering.Blocks {
             }
 
             if (mesh == null) {
-                Shape shape;
+                Shape shape = null;
                 if (stack.Class == EnumItemClass.Item) {
                     if ((stack.Item as ItemWorkItem) != null) {
                         return new MeshData();
-                    } else {
-                        shape = capi.TesselatorManager.GetCachedShape(stack.Item.Shape.Base);
+                    }
+                    AssetLocation shapeBase = stack.Item?.Shape?.Base;
+                    if (shapeBase != null) {
+                        shape = capi.TesselatorManager.GetCachedShape(shapeBase);
                     }
                 } else {
-                    shape = capi.TesselatorManager.GetCachedShape(stack.Block.Shape.Base);
+                    AssetLocation shapeBase = stack.Block?.Shape?.Base;
+                    if (shapeBase != null) {
+                        shape = capi.TesselatorManager.GetCachedShape(shapeBase);
+                    }
                 }
 
                 if (shape == null) {


### PR DESCRIPTION
Two fixes bundled. Both reproduced on 1.22.2 with current upstream master + a heavily-modded loadout.

## Workbench NRE in `GetOrCreateFullSlotMesh` / `GetOrCreateReforgeSlotMesh`

A user on Discord posted this stack trace from `toolsmith@1.2.15`:

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at Toolsmith.ToolTinkering.Blocks.BlockEntityWorkbench.GetOrCreateFullSlotMesh(ItemStack stack, Int32 slotIndex) ... line 625
   at Toolsmith.ToolTinkering.Blocks.BlockEntityWorkbench.UpdateMesh(Int32 i) ... line 478
   at Toolsmith.ToolTinkering.Blocks.BlockEntityWorkbench.<>c__DisplayClass51_0.<SchedulePrecacheOnMainThread>b__0() ... line 856
```

`stack.Item.Shape.Base` (line 625) and `stack.Block.Shape.Base` (line 628) were dereferenced without a null check. Items with no explicit `shape` in their JSON, or items that resolve their shape per-variant via `shapeByType`, can have a null `Item.Shape` when the precache task fires. The unguarded path existed before, but the main-thread precache scheduled by `SchedulePrecacheOnMainThread` runs `UpdateMesh` for every crafting/reforge slot transition, which lit it up reliably under heavily-modded loadouts.

Fix: route a null `Shape.Base` to the existing `shape == null` fallback (lines 631-639), which either uses the marker mesh or returns an empty `MeshData` depending on the client config. No new branches needed. The same change is applied to both `GetOrCreateFullSlotMesh` and `GetOrCreateReforgeSlotMesh`, which had identical shape.

## Tool-head dupe on ground-storage interaction

Reported by a user with v1.21.6 + repro'd on v1.22.2:

> Holding a valid handle in the offhand, attempt to place a tool head in an already partially occupied "quadrant" ground storage. Game crashes, appears to also be a duplication glitch.

Confirmed the dupe by reading the in-game audit log. Multiple `Put` events for the same item at the same coordinates, no intervening `Take`:

```
12:33:14 Put 1xgame:pickaxehead-copper into Ground storage at 512422, 112, 512110.
12:33:15 Put 1xgame:pickaxehead-copper into Ground storage at 512422, 112, 512110.
12:33:16 Put 1xgame:pickaxehead-copper into Ground storage at 512422, 112, 512110.
12:33:16 Put 1xgame:pickaxehead-copper into Ground storage at 512422, 112, 512110.
```

`CollectibleBehaviorToolHead.OnHeldInteractStart` sets `PreventDefault` on the held item and marks the stack as `PartBeingCrafted` when there's a valid handle in offhand. But `PreventDefault` on the held item doesn't stop `BlockEntityGroundStorage` from running its own `OnBlockInteractStart` and depositing the head. The two handlers race per tick, and the player slot ends up out of sync with what got stored.

Fix: when `blockSel` resolves to a `BlockEntityGroundStorage`, skip the crafting intercept and fall through to the base interaction so vanilla handles the deposit cleanly. Couldn't reproduce the exact crash from the original report (probably specific to a state I didn't hit), but the dupe is gone and the most plausible NRE site is no longer reachable.

### Trade-off worth flagging

After the fix, the player can't start tinker-crafting while looking at any ground-storage block, even an empty quadrant. Same convention as "can't craft while looking at a chest", but it's a small UX cost worth being aware of. A more surgical fix would require asking `BlockEntityGroundStorage` whether the targeted quadrant will accept this specific item before committing to defer, which is more invasive than the issue justifies for a single-line guard. Happy to revise if you'd rather refine it.

## Smoke test

- VS 1.22.2, heavily modded loadout (~150 mods including most of the tinkering-adjacent ecosystem)
- Workbench: built several tools end to end, no NRE, normal mesh rendering across crafting/reforge slots
- Ground storage with tool head + offhand handle: deposit now fires exactly once per click, audit log clean
- Confirmed crafting still works normally when targeting non-storage blocks

---

*`Tirello`*  
*ModDB · Forums · Discord*