### PR TITLE
Fix BlockEntityWorkbench NRE, and small String Sense compatibility update

### DIFF
--- a/Toolsmith/ToolTinkering/Blocks/BlockEntityWorkbench.cs
+++ b/Toolsmith/ToolTinkering/Blocks/BlockEntityWorkbench.cs
@@ -646,7 +646,7 @@ namespace Toolsmith.ToolTinkering.Blocks {
                 ShapeTextureSource texSource = new(capi, shape, "For rendering item on a Workbench");
                 texSource.textures.Clear();
 
-                if (shape.Textures == null || shape.Textures.Count > 0) {
+                if (shape.Textures != null && shape.Textures.Count > 0) {
                     foreach ((string texCode, AssetLocation assetLoc) in shape.Textures) { //Go through the shape's textures and populate the texSource with any that the shape already has defined
                         if (stack.Class == EnumItemClass.Item && stack.Item.Textures.TryGetValue(texCode, out CompositeTexture texture)) { //Grab the item's own textures to slap on instead of the shape's base, or just run with the base.
                             texSource.textures[texCode] = texture;

--- a/Toolsmith/assets/toolsmith/config/toolsmith/parts/bindings/bindings-stringsense.json
+++ b/Toolsmith/assets/toolsmith/config/toolsmith/parts/bindings/bindings-stringsense.json
@@ -24,6 +24,12 @@
         "bindingTextureOverride": "stringsense:flax/cord"
     },
     {
+        "id": "cord-mixed",
+        "bindingStatTag": "reeds",
+        "bindingShapePath": "string",
+        "bindingTextureOverride": "stringsense:mixed/cord"
+    },
+    {
         "id": "cord-nzflax",
         "bindingStatTag": "reeds",
         "bindingShapePath": "string",


### PR DESCRIPTION
Two unrelated little changes:

- Fixed a null reference exception in BlockEntityWorkbench
- Added a missing cord type in String Sense compatibility