### PR TITLE
Workbench Shape null-guards + transpiler hardening + String Sense compat

### DIFF
--- a/Toolsmith/ToolTinkering/Blocks/BlockEntityWorkbench.cs
+++ b/Toolsmith/ToolTinkering/Blocks/BlockEntityWorkbench.cs
@@ -646,7 +646,7 @@ namespace Toolsmith.ToolTinkering.Blocks {
                 ShapeTextureSource texSource = new(capi, shape, "For rendering item on a Workbench");
                 texSource.textures.Clear();
 
-                if (shape.Textures == null || shape.Textures.Count > 0) {
+                if (shape.Textures != null && shape.Textures.Count > 0) {
                     foreach ((string texCode, AssetLocation assetLoc) in shape.Textures) { //Go through the shape's textures and populate the texSource with any that the shape already has defined
                         if (stack.Class == EnumItemClass.Item && stack.Item.Textures.TryGetValue(texCode, out CompositeTexture texture)) { //Grab the item's own textures to slap on instead of the shape's base, or just run with the base.
                             texSource.textures[texCode] = texture;
@@ -756,7 +756,7 @@ namespace Toolsmith.ToolTinkering.Blocks {
                 ShapeTextureSource texSource = new(capi, shape, "For rendering item on a Workbench");
                 texSource.textures.Clear();
 
-                if (shape.Textures == null || shape.Textures.Count > 0) {
+                if (shape.Textures != null && shape.Textures.Count > 0) {
                     foreach ((string texCode, AssetLocation assetLoc) in shape.Textures) { //Go through the shape's textures and populate the texSource with any that the shape already has defined
                         if (stack.Class == EnumItemClass.Item && stack.Item.Textures.TryGetValue(texCode, out CompositeTexture texture)) { //Grab the item's own textures to slap on instead of the shape's base, or just run with the base.
                             texSource.textures[texCode] = texture;

--- a/Toolsmith/ToolTinkering/ToolRenderingPatches.cs
+++ b/Toolsmith/ToolTinkering/ToolRenderingPatches.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection.Emit;
 using System.Text;
 using System.Threading.Tasks;
+using Toolsmith;
 using Vintagestory.API.Common;
 using Vintagestory.GameContent;
 
@@ -30,6 +31,11 @@ namespace Toolsmith.ToolTinkering {
                 CodeInstruction.LoadArgument(1),
                 new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(CollectibleObject), "OnLoaded", new Type[1] { typeof(ICoreAPI) }))
             };
+
+            if (codes.Count <= 5) {
+                ToolsmithModSystem.Logger?.Warning("Toolsmith: ItemHoe.OnLoaded IL has fewer instructions than expected ({0}); skipping base-call insertion.", codes.Count);
+                return instructions;
+            }
 
             codes.InsertRange(5, addBaseCall);
 

--- a/Toolsmith/Utils/ItemStackExtensions.cs
+++ b/Toolsmith/Utils/ItemStackExtensions.cs
@@ -456,7 +456,21 @@ namespace Toolsmith.Utils {
                 }
 
                 var baseDur = itemStack.Collectible.GetBaseMaxDurability(itemStack);
-                var headStack = new ItemStack(world.GetItem(new AssetLocation(headCode)), 1);
+                var headItem = world.GetItem(new AssetLocation(headCode));
+                if (headItem == null) {
+                    //Head code resolved from the GridRecipes dictionary but no item with that code is registered
+                    //in the current load (mod uninstalled, modid renamed in a takeover, or wildcard resolved
+                    //without a backing item). Route through the same fallback the "headCode is null" path above uses.
+                    ToolsmithModSystem.Logger.Error("Tool head code '" + headCode + "' resolved from the GridRecipes Dictionary but no item with that code is registered. The mod that provided it is likely uninstalled or has been renamed. Adding " + itemStack.Collectible.Code + " to the ignore list and assigning placeholder values.");
+                    ToolsmithModSystem.IgnoreCodes.Add(itemStack.Collectible.Code.ToString());
+                    var headStackBackup = new ItemStack(world.GetItem(new AssetLocation(ToolsmithConstants.FallbackHeadCode)), 1);
+                    itemStack.SetToolhead(headStackBackup);
+                    itemStack.SetToolheadCurrentDurability(1);
+                    itemStack.SetToolCurrentSharpness(1);
+                    itemStack.SetToolMaxSharpness(1);
+                    return;
+                }
+                var headStack = new ItemStack(headItem, 1);
                 var headDur = (int)(itemStack.Attributes.GetInt(ToolsmithAttributes.Durability, baseDur) * ToolsmithModSystem.Config.HeadDurabilityMult); //If the tool has already been used some, this hopefully should reset it to have the head-damage be the existing durability, but generate new binding and handle stats.
                 var headMaxDur = itemStack.GetToolheadMaxDurability();
 

--- a/Toolsmith/assets/toolsmith/config/toolsmith/parts/bindings/bindings-stringsense.json
+++ b/Toolsmith/assets/toolsmith/config/toolsmith/parts/bindings/bindings-stringsense.json
@@ -24,6 +24,12 @@
         "bindingTextureOverride": "stringsense:flax/cord"
     },
     {
+        "id": "cord-mixed",
+        "bindingStatTag": "reeds",
+        "bindingShapePath": "string",
+        "bindingTextureOverride": "stringsense:mixed/cord"
+    },
+    {
         "id": "cord-nzflax",
         "bindingStatTag": "reeds",
         "bindingShapePath": "string",


### PR DESCRIPTION
## Summary
Four small defensive changes from a 1.22 smoke-testing pass. Three address null and edge-case crash paths in the workbench, the ItemHoe transpiler, and the tool head item lookup; one is a String Sense binding compatibility addition.

## Relationship to #45
Overlaps with @averixus's PR #45 on the workbench NRE. The same buggy condition exists at two places in `BlockEntityWorkbench.cs` (lines 646 and 756); #45 fixes line 646, this PR fixes both sites. The String Sense `cord-mixed` JSON addition from #45 is included here so it doesn't get orphaned if this lands first. Happy to defer or combine however is easiest.

## Changes

### 1. Workbench Shape null-guards
`BlockEntityWorkbench.cs` had `if (shape.Textures == null || shape.Textures.Count > 0)` at both render paths. The `||` makes the foreach run on null textures, which NREs. Flipped both to `if (shape.Textures != null && shape.Textures.Count > 0)`.

### 2. ItemHoe.OnLoaded transpiler IL-drift guard
`ToolRenderingPatches.cs` called `codes.InsertRange(5, addBaseCall)` unconditionally. If a future VS update changes the IL so there are fewer than 6 instructions, that throws IndexOutOfRange and aborts the entire patch system. Added a length check: when the IL is shorter than expected, log a warning and return the instructions unchanged so the patch system continues with other classes.

### 3. ItemStackExtensions head-item null fallback
When a tool's head code is registered in the GridRecipes dictionary but the backing item isn't loaded (mod uninstalled, modid renamed in a takeover, wildcard resolved without a backing item), `world.GetItem(...)` returns null and the next `new ItemStack(...)` NREs. Routed this case through the same fallback the "headCode is null" path above already uses: add to ignore list, assign placeholder durability/sharpness values, return.

### 4. String Sense `cord-mixed` binding
Adds the `cord-mixed` cord type to `bindings-stringsense.json`. Same content as #45.

## Testing
Tested in single-player on VS 1.22:
- Multiple tool parts (head + two handle variants + steel nails) placed into workbench, all render correctly.
- Multiple hoe heads dropped into a chest, overlay renders correctly, no crashes.
- Crafting a hoe, no issues.

Client log: 0 errors, 0 transpiler patch failures.

## Migration notes
None. No breaking changes.