### PR TITLE
Null-guard and thread-safety fixes for workbench rendering, handle crafting, and tool breaks

### DIFF
--- a/Toolsmith/ToolTinkering/Behaviors/CollectibleBehaviorToolHandle.cs
+++ b/Toolsmith/ToolTinkering/Behaviors/CollectibleBehaviorToolHandle.cs
@@ -47,7 +47,11 @@ namespace Toolsmith.ToolTinkering.Behaviors {
             base.GetHeldItemInfo(inSlot, dsc, world, withDebugInfo);
 
             if (world.Api.Side.IsClient()) {
-                var handleStats = ToolsmithModSystem.Stats.BaseHandleStats.Get(ToolsmithModSystem.Stats.BaseHandleParts.Get(inSlot.Itemstack.Collectible.Code.Path).handleStatTag);
+                var handlePart = ToolsmithModSystem.Stats.BaseHandleParts.Get(inSlot.Itemstack.Collectible.Code.Path);
+                if (handlePart == null) {
+                    return;
+                }
+                var handleStats = ToolsmithModSystem.Stats.BaseHandleStats.Get(handlePart.handleStatTag);
                 if (handleStats != null) {
                     var totalHandleMult = handleStats.baseHPfactor * (1 + handleStats.selfHPBonus);
                     dsc.AppendLine("");
@@ -88,7 +92,7 @@ namespace Toolsmith.ToolTinkering.Behaviors {
             ItemSlot gripOrTreatmentSlot = null;
 
             foreach (var slot in allInputslots) {
-                if (!slot.Empty && (slot.Itemstack.Collectible.Code != ToolsmithConstants.SandpaperCode || slot.Itemstack.Collectible.Code != ToolsmithConstants.FirewoodCode)) {
+                if (!slot.Empty && (slot.Itemstack.Collectible.Code != ToolsmithConstants.SandpaperCode && slot.Itemstack.Collectible.Code != ToolsmithConstants.FirewoodCode)) {
                     if (slot.Itemstack.Collectible.Tool != null) {
                         toolSlot = slot;
                     } else if (slot.Itemstack.Collectible.Code.FirstCodePart() == ToolsmithConstants.HandleBlankCode) {
@@ -194,8 +198,13 @@ namespace Toolsmith.ToolTinkering.Behaviors {
                         }
 
                         var treatmentStatPair = ToolsmithModSystem.Stats.TreatmentParts.TryGetValue(treatment.Collectible.Code.Path);
-                        var treatmentStats = ToolsmithModSystem.Stats.TreatmentStats.TryGetValue(treatmentStatPair.treatmentStatTag);
+                        var treatmentStats = treatmentStatPair != null ? ToolsmithModSystem.Stats.TreatmentStats.TryGetValue(treatmentStatPair.treatmentStatTag) : null;
                         var handleStatPair = ToolsmithModSystem.Stats.BaseHandleParts.TryGetValue(handleSlot.Itemstack.Collectible.Code.Path);
+                        if (treatmentStats == null || handleStatPair == null) {
+                            ToolsmithModSystem.Logger.Error("A handle was crafted with " + treatment.Collectible.Code + " but it has no treatment stats registered. It will not apply any treatment.");
+                            outputSlot.MarkDirty();
+                            return;
+                        }
                         outputSlot.Itemstack.SetHandleTreatmentTag(treatmentStats.id);
                         outputSlot.Itemstack.SetWetTreatment((int)(treatmentStatPair.dryingHours * handleStatPair.dryingTimeMult));
                         outputSlot.Itemstack.Collectible.SetTransitionState(outputSlot.Itemstack, EnumTransitionType.Dry, 0);

--- a/Toolsmith/ToolTinkering/Blocks/BlockEntityWorkbench.cs
+++ b/Toolsmith/ToolTinkering/Blocks/BlockEntityWorkbench.cs
@@ -2,6 +2,7 @@
 using SmithingPlus.Util;
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using System.Linq;
@@ -24,7 +25,8 @@ namespace Toolsmith.ToolTinkering.Blocks {
 
         protected WorkbenchInventory Inventory { get; private set; }
         protected ICoreClientAPI capi;
-        protected Dictionary<string, MeshData> WorkbenchItemMeshCache => ObjectCacheUtil.GetOrCreate(Api, ToolsmithConstants.WorkbenchItemRenderingMeshRefs, () => new Dictionary<string, MeshData>());
+        //This cache is read on the chunk-tesselation worker thread in OnTesselation while the main thread fills it in UpdateMesh, so it needs to be a ConcurrentDictionary.
+        protected ConcurrentDictionary<string, MeshData> WorkbenchItemMeshCache => ObjectCacheUtil.GetOrCreate(Api, ToolsmithConstants.WorkbenchItemRenderingMeshRefs, () => new ConcurrentDictionary<string, MeshData>());
         private (float x, float y, float z)[] offsetBySlot = { (0f, 0f, 0f), (0.4f, 1f, 0.3f), (0.6f, 1f, 0.6f), (0.8f, 1f, 0.3f), (1.0f, 1f, 0.6f), (1.2f, 1f, 0.3f), (0f, 0f, 0f), (1.65f, 1f, 0.55f) };
 
         private int craftingHitsCount = 0;
@@ -613,7 +615,7 @@ namespace Toolsmith.ToolTinkering.Blocks {
                         }
                         break;
                 }
-                markerMeshData = originalMeshData.Clone();
+                markerMeshData = originalMeshData?.Clone(); //Null when the marker lookup above missed - everything below already handles a null marker, so the item still shows like the warnings promise.
             }
 
             if (mesh == null) {
@@ -648,9 +650,9 @@ namespace Toolsmith.ToolTinkering.Blocks {
 
                 if (shape.Textures != null && shape.Textures.Count > 0) {
                     foreach ((string texCode, AssetLocation assetLoc) in shape.Textures) { //Go through the shape's textures and populate the texSource with any that the shape already has defined
-                        if (stack.Class == EnumItemClass.Item && stack.Item.Textures.TryGetValue(texCode, out CompositeTexture texture)) { //Grab the item's own textures to slap on instead of the shape's base, or just run with the base.
+                        if (stack.Class == EnumItemClass.Item && stack.Item.Textures != null && stack.Item.Textures.TryGetValue(texCode, out CompositeTexture texture)) { //Grab the item's own textures to slap on instead of the shape's base, or just run with the base.
                             texSource.textures[texCode] = texture;
-                        } else if (stack.Class == EnumItemClass.Block && stack.Block.Textures.TryGetValue(texCode, out CompositeTexture blockTexture)) {
+                        } else if (stack.Class == EnumItemClass.Block && stack.Block.Textures != null && stack.Block.Textures.TryGetValue(texCode, out CompositeTexture blockTexture)) {
                             texSource.textures[texCode] = blockTexture;
                         } else {
                             texSource.textures[texCode] = new CompositeTexture(assetLoc);
@@ -758,9 +760,9 @@ namespace Toolsmith.ToolTinkering.Blocks {
 
                 if (shape.Textures != null && shape.Textures.Count > 0) {
                     foreach ((string texCode, AssetLocation assetLoc) in shape.Textures) { //Go through the shape's textures and populate the texSource with any that the shape already has defined
-                        if (stack.Class == EnumItemClass.Item && stack.Item.Textures.TryGetValue(texCode, out CompositeTexture texture)) { //Grab the item's own textures to slap on instead of the shape's base, or just run with the base.
+                        if (stack.Class == EnumItemClass.Item && stack.Item.Textures != null && stack.Item.Textures.TryGetValue(texCode, out CompositeTexture texture)) { //Grab the item's own textures to slap on instead of the shape's base, or just run with the base.
                             texSource.textures[texCode] = texture;
-                        } else if (stack.Class == EnumItemClass.Block && stack.Block.Textures.TryGetValue(texCode, out CompositeTexture blockTexture)) {
+                        } else if (stack.Class == EnumItemClass.Block && stack.Block.Textures != null && stack.Block.Textures.TryGetValue(texCode, out CompositeTexture blockTexture)) {
                             texSource.textures[texCode] = blockTexture;
                         } else {
                             texSource.textures[texCode] = new CompositeTexture(assetLoc);
@@ -856,13 +858,13 @@ namespace Toolsmith.ToolTinkering.Blocks {
             return base.OnTesselation(mesher, tessThreadTesselator);
         }
 
-        private readonly HashSet<int> pendingSlotPrecaches = new();
+        //Added to from the tesselation worker thread and cleared on the main thread, so this can't be a plain HashSet.
+        private readonly ConcurrentDictionary<int, byte> pendingSlotPrecaches = new();
         private void SchedulePrecacheOnMainThread(int slotIndex) {
             if (capi == null) return;
-            if (pendingSlotPrecaches.Contains(slotIndex)) return;
-            pendingSlotPrecaches.Add(slotIndex);
+            if (!pendingSlotPrecaches.TryAdd(slotIndex, 0)) return;
             capi.Event.EnqueueMainThreadTask(() => {
-                pendingSlotPrecaches.Remove(slotIndex);
+                pendingSlotPrecaches.TryRemove(slotIndex, out _);
                 UpdateMesh(slotIndex);
                 MarkDirty(redrawOnClient: true);
             }, "ToolsmithWorkbenchMeshPrecache");

--- a/Toolsmith/ToolTinkering/TinkeringUtility.cs
+++ b/Toolsmith/ToolTinkering/TinkeringUtility.cs
@@ -269,20 +269,25 @@ namespace Toolsmith.ToolTinkering {
                 }
             }
             if (toolBinding != null) { //Binding doesn't always drop, only if the durability is above the threshold, and then if it's below, it breaks and if made of metal, drops some bits
-                BindingStatDefines bindingStats = ToolsmithModSystem.Stats.BindingStats.Get(ToolsmithModSystem.Stats.BindingParts.Get(toolBinding.Collectible.Code.Path).bindingStatTag);
-                float bindingPercentRemains = (float)(remainingBindingDur) / (float)(brokenToolStack.GetToolbindingMaxDurability());
-                if (bindingPercentRemains < bindingStats.recoveryPercent) { //If the remaining HP percent is less then the recovery percent, the binding is used up.
-                    toolBinding = null; //Set it back to null to prevent dropping anything later! And then to see if Bits should drop!
-                }
-
-                if (toolBinding == null && bindingStats.isMetal) {
-                    int numBits;
-                    if (world.Rand.NextDouble() < 0.5) {
-                        numBits = ToolsmithConstants.NumBitsReturnMinimum;
-                    } else {
-                        numBits = ToolsmithConstants.NumBitsReturnMinimum + 1;
+                var bindingPart = ToolsmithModSystem.Stats.BindingParts.Get(toolBinding.Collectible.Code.Path);
+                BindingStatDefines bindingStats = bindingPart != null ? ToolsmithModSystem.Stats.BindingStats.Get(bindingPart.bindingStatTag) : null;
+                if (bindingStats == null) { //A saved tool can hold a binding that no longer has any stats registered, likely from a config change or removed compat mod. Nothing sensible to drop then.
+                    toolBinding = null;
+                } else {
+                    float bindingPercentRemains = (float)(remainingBindingDur) / (float)(brokenToolStack.GetToolbindingMaxDurability());
+                    if (bindingPercentRemains < bindingStats.recoveryPercent) { //If the remaining HP percent is less then the recovery percent, the binding is used up.
+                        toolBinding = null; //Set it back to null to prevent dropping anything later! And then to see if Bits should drop!
                     }
-                    bitsDrop = new ItemStack(world.GetItem(new AssetLocation("game:metalbit-" + bindingStats.metalType)), numBits);
+
+                    if (toolBinding == null && bindingStats.isMetal) {
+                        int numBits;
+                        if (world.Rand.NextDouble() < 0.5) {
+                            numBits = ToolsmithConstants.NumBitsReturnMinimum;
+                        } else {
+                            numBits = ToolsmithConstants.NumBitsReturnMinimum + 1;
+                        }
+                        bitsDrop = new ItemStack(world.GetItem(new AssetLocation("game:metalbit-" + bindingStats.metalType)), numBits);
+                    }
                 }
             }
 

--- a/Toolsmith/ToolTinkering/ToolTinkeringPatches.cs
+++ b/Toolsmith/ToolTinkering/ToolTinkeringPatches.cs
@@ -272,14 +272,15 @@ namespace Toolsmith.ToolTinkering {
             var getItemStack = AccessTools.Method(typeof(ItemSlot), "get_Itemstack");
             var toolsmithShouldRenderSharpness = AccessTools.Method(typeof(TinkeringUtility), "ShouldRenderSharpnessBar", new Type[1] { typeof(ItemStack) });
 
-            var shouldRenderSharpnessAddition = new List<CodeInstruction> {
-                CodeInstruction.LoadArgument(1),
-                new CodeInstruction(OpCodes.Call, getItemStack),
-                new CodeInstruction(OpCodes.Call, toolsmithShouldRenderSharpness),
-                new CodeInstruction(OpCodes.Brtrue_S, codes[indexOfShouldRenderDamageCheck].operand)
-            };
-
             if (index >= 0 && indexOfSecondRet >= 0 && indexOfShouldRenderDamageCheck >= 0 && indexOfDamageColor >= 0 && indexOfGetMaxDur >= 0 && indexOfGetRemainingDur >= 0) {
+                //Only build this after the indexes are validated - indexing codes with a -1 would throw here and skip the helpful error messages below.
+                var shouldRenderSharpnessAddition = new List<CodeInstruction> {
+                    CodeInstruction.LoadArgument(1),
+                    new CodeInstruction(OpCodes.Call, getItemStack),
+                    new CodeInstruction(OpCodes.Call, toolsmithShouldRenderSharpness),
+                    new CodeInstruction(OpCodes.Brtrue_S, codes[indexOfShouldRenderDamageCheck].operand)
+                };
+
                 codeAddition[0].MoveLabelsFrom(codes[index]);
                 codes.InsertRange(index, codeAddition);
                 codes[indexOfDamageColor - 5].opcode = OpCodes.Nop;


### PR DESCRIPTION
A follow-up batch of defensive fixes in the same spirit as #46. Each of these is a crash or logic slip that only fires under specific conditions, so they are easy to miss in normal play. Everything builds clean against 1.22 with zero warnings.

### ComposeSlotOverlays transpiler builds its IL insert before validating indexes (ToolTinkeringPatches.cs)

The `shouldRenderSharpnessAddition` list reads `codes[indexOfShouldRenderDamageCheck].operand` before the `>= 0` validation runs. If a future game update shifts the IL so the pattern scan misses, the list construction throws `ArgumentOutOfRangeException` during patching, and the helpful error messages in the else branch never get a chance to run. Moved the construction inside the validated branch. Same class of problem as the ItemHoe transpiler guard from #46, just at the other site.

### Workbench mesh caches are shared across threads without synchronization (BlockEntityWorkbench.cs)

`OnTesselation` runs on the chunk tesselation worker thread and reads `WorkbenchItemMeshCache`, while `UpdateMesh` fills it on the main thread. `Dictionary` is not safe for a concurrent read and write; a resize during a read can throw or hang. Same story for `pendingSlotPrecaches`, a `HashSet` touched from both threads. Swapped both to `ConcurrentDictionary`. `TryAdd` also closes the small Contains/Add race window in the scheduling path.

### The "Item should still show" fallback NREs instead (BlockEntityWorkbench.cs)

In `GetOrCreateFullSlotMesh`, a slot marker cache miss logs "Marker will not Render, but Item should still show" and then immediately calls `originalMeshData.Clone()` on the null result. Everything downstream already null-checks `markerMeshData`, so a null-conditional `Clone` makes the fallback behave the way the warning promises.

### stack.Item.Textures dereferenced without a null check (BlockEntityWorkbench.cs)

Both slot mesh methods call `stack.Item.Textures.TryGetValue` guarded only by the item class check. An item with no textures block in its json has a null `Textures`. The later else-if branch already null-checks the same property, which is exactly the case this misses. Added the same guard to the Item and Block lookups in both methods.

### The sandpaper/firewood exclusion is always true (CollectibleBehaviorToolHandle.cs)

`code != Sandpaper || code != Firewood` can never be false, so nothing was ever excluded from slot classification. Recipe ordering happens to dodge it today, but any recipe that pairs a handle with an unregistered ingredient falls through to the treatment path and NREs on the missing stats, which eats the craft. Flipped it to `&&`, and also null-guarded the treatment and handle stat lookups so an unregistered ingredient logs an error and leaves the handle untreated instead of throwing.

### Two chained stat lookups NRE on stale saved parts (TinkeringUtility.cs, CollectibleBehaviorToolHandle.cs)

`BindingStats.Get(BindingParts.Get(path).bindingStatTag)` NREs when the part is no longer registered, which can happen with saved tools after a config change or a removed compat mod. `CollectibleBehaviorToolBinding` already does this same lookup with null checks at both steps, so these two sites now match it. On tool break, an unregistered binding simply does not drop anything.

---

One non-change worth mentioning: I also went over the ScientificSmithy compat sites while I was in here. The `ScientificSmithyAttr` reads are const fields, so they compile down to inlined strings and are safe without the mod installed, and the one real cross-assembly call (`TransferStressStrainAttr`) is correctly isolated behind the `IsModEnabled` gate in its own helper. No changes needed there.
